### PR TITLE
Remove arbitrary catch

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/redis/RedisFingerprintStorage.java
+++ b/plugin/src/main/java/io/jenkins/plugins/redis/RedisFingerprintStorage.java
@@ -65,13 +65,8 @@ public class RedisFingerprintStorage extends FingerprintStorage {
     }
 
     public RedisFingerprintStorage() throws IOException {
-        try {
-            instanceId = Util.getDigestOf(new ByteArrayInputStream(InstanceIdentity.get().getPublic().getEncoded()));
-            createJedisPoolFromConfig();
-        } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Failed to obtain Instance ID", e);
-            throw e;
-        }
+        instanceId = Util.getDigestOf(new ByteArrayInputStream(InstanceIdentity.get().getPublic().getEncoded()));
+        createJedisPoolFromConfig();
     }
 
     void createJedisPoolFromConfig() {


### PR DESCRIPTION
`IOException` is thrown when MD5 is not installed. This is
* hard to test
* better to have an error thrown than to catch it as something it is not