### PR TITLE
Remove Enabled Property

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 def configurations = [
-    [ platform: "linux", jdk: "8", jenkins: "2.241-rc30112.2463bcdaa03f" ],
-    [ platform: "linux", jdk: "11", jenkins: "2.241-rc30112.2463bcdaa03f", javaLevel: "8" ]
+    [ platform: "linux", jdk: "8", jenkins: "2.242-rc30049.a5310b10d6f4" ],
+    [ platform: "linux", jdk: "11", jenkins: "2.242-rc30049.a5310b10d6f4", javaLevel: "8" ]
 ]
 buildPlugin(configurations: configurations)

--- a/plugin/src/main/java/io/jenkins/plugins/redis/GlobalRedisConfiguration.java
+++ b/plugin/src/main/java/io/jenkins/plugins/redis/GlobalRedisConfiguration.java
@@ -61,7 +61,6 @@ import java.util.List;
 @Symbol("redis")
 public class GlobalRedisConfiguration extends GlobalConfiguration {
 
-    private boolean enabled;
     private String host = "localhost";
     private int port = 6379;
     private int database = 0;
@@ -72,24 +71,10 @@ public class GlobalRedisConfiguration extends GlobalConfiguration {
 
     public GlobalRedisConfiguration() {
         load();
-        setEnabled(this.enabled);
     }
 
     public static GlobalRedisConfiguration get() {
         return GlobalConfiguration.all().getInstance(GlobalRedisConfiguration.class);
-    }
-
-    public boolean getEnabled() {
-        return enabled;
-    }
-
-    void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-        if (enabled){
-            System.setProperty("FingerprintStorageEngine", "io.jenkins.plugins.redis.RedisFingerprintStorage");
-        } else {
-            System.setProperty("FingerprintStorageEngine", "jenkins.fingerprints.FileFingerprintStorage");
-        }
     }
 
     public String getHost() {
@@ -192,7 +177,6 @@ public class GlobalRedisConfiguration extends GlobalConfiguration {
     @Override
     public boolean configure(StaplerRequest req, JSONObject json) {
         json = json.getJSONObject("redis");
-        setEnabled(json.getBoolean("enabled"));
         setHost(json.getString("host"));
         setPort(json.getInt("port"));
         setDatabase(json.getInt("database"));

--- a/plugin/src/main/resources/io/jenkins/plugins/redis/GlobalRedisConfiguration/config.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/redis/GlobalRedisConfiguration/config.jelly
@@ -53,8 +53,5 @@ THE SOFTWARE.
             CAUTION: It is the responsibility of the admins to ensure the security of the Redis instance as fingerprints
             may contain sensitive information.
         </f:entry>
-        <f:entry title="Enabled">
-            <f:checkbox field="enabled" default="${it.enabled}" />
-        </f:entry>
     </f:section>
 </j:jelly>

--- a/plugin/src/test/java/io/jenkins/plugins/redis/GlobalRedisConfigurationTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/redis/GlobalRedisConfigurationTest.java
@@ -53,7 +53,6 @@ public class GlobalRedisConfigurationTest {
         GlobalRedisConfiguration g = GlobalRedisConfiguration.get();
         g.setSocketTimeout(3000);
         g.setConnectionTimeout(3000);
-        g.setEnabled(true);
         g.setCredentialsId("dummy");
         g.setDatabase(0);
         g.setHost("dummy");

--- a/plugin/src/test/java/io/jenkins/plugins/redis/RedisFingerprintStorageTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/redis/RedisFingerprintStorageTest.java
@@ -68,7 +68,6 @@ public class RedisFingerprintStorageTest {
         GlobalRedisConfiguration redisConfiguration = GlobalRedisConfiguration.get();
         String host = redis.getHost();
         Integer port = redis.getFirstMappedPort();
-        redisConfiguration.setEnabled(true);
         RedisFingerprintStorage redisFingerprintStorage = RedisFingerprintStorage.get();
         redisFingerprintStorage.createJedisPool(host, port, 2000, 2000,
                 "default", "", 0, false);
@@ -79,7 +78,6 @@ public class RedisFingerprintStorageTest {
      */
     private void setIncorrectConfiguration() {
         GlobalRedisConfiguration redisConfiguration = GlobalRedisConfiguration.get();
-        redisConfiguration.setEnabled(true);
         RedisFingerprintStorage redisFingerprintStorage = RedisFingerprintStorage.get();
         redisFingerprintStorage.createJedisPool("", 0, 2000, 2000, "default", "", 0, false);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@ THE SOFTWARE.
 
     <properties>
         <!-- TODO https://github.com/jenkinsci/jenkins/pull/4731 -->
-        <jenkins.version>2.241-rc30112.2463bcdaa03f</jenkins.version>
+        <jenkins.version>2.242-rc30049.a5310b10d6f4</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
     </properties>


### PR DESCRIPTION
This PR removes the ability of the plugin to enable/disable itself. This was discussed in meetings that it is better to leave this control to Jenkins core. As of now, Jenkins core enables any configured external storage plugin at startup. Later on we can make this configurable directly in Jenkins core by introducing a Global config page.