### PR TITLE
Remove experimental update center instructions from README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,19 +13,13 @@ The plugin allows users to configure Redis for storing fingerprints.
 
 == Installation
 
-The plugin can be installed using the link:https://www.jenkins.io/doc/developer/publishing/releasing-experimental-updates/[experimental update center].
+The plugin can be installed using the Jenkins Update Center.
 
 Follow along the following steps after running Jenkins to download and install the plugin:
 
 . Select `Manage Jenkins`
 
 . Select `Manage Plugins`
-
-. Go to `Advanced` tab
-
-. Configure the Update Site URL as: https://updates.jenkins.io/experimental/update-center.json
-
-. Click on `Submit`, and then press the `Check Now` button.
 
 . Go to `Available` tab.
 


### PR DESCRIPTION
Since the plugin is now available on update center, it makes sense to remove the experimental update center instructions from README.