### PR TITLE
Add help pages for all supported parameters

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/redis/RedisFingerprintStorage/help-connectionTimeout.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/redis/RedisFingerprintStorage/help-connectionTimeout.html
@@ -1,0 +1,27 @@
+<!--
+The MIT License
+
+Copyright (c) 2020, Jenkins project contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<div>
+    Set the connection timeout duration in milliseconds.
+</div>

--- a/plugin/src/main/resources/io/jenkins/plugins/redis/RedisFingerprintStorage/help-credentialsId.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/redis/RedisFingerprintStorage/help-credentialsId.html
@@ -1,0 +1,27 @@
+<!--
+The MIT License
+
+Copyright (c) 2020, Jenkins project contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<div>
+    Configure authentication using username and password to the Redis instance.
+</div>

--- a/plugin/src/main/resources/io/jenkins/plugins/redis/RedisFingerprintStorage/help-database.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/redis/RedisFingerprintStorage/help-database.html
@@ -1,0 +1,27 @@
+<!--
+The MIT License
+
+Copyright (c) 2020, Jenkins project contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<div>
+    Redis supports integer indexed databases, which can be specified here.
+</div>

--- a/plugin/src/main/resources/io/jenkins/plugins/redis/RedisFingerprintStorage/help-host.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/redis/RedisFingerprintStorage/help-host.html
@@ -1,0 +1,27 @@
+<!--
+The MIT License
+
+Copyright (c) 2020, Jenkins project contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<div>
+    Enter hostname where Redis is running
+</div>

--- a/plugin/src/main/resources/io/jenkins/plugins/redis/RedisFingerprintStorage/help-host.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/redis/RedisFingerprintStorage/help-host.html
@@ -23,5 +23,5 @@ THE SOFTWARE.
 -->
 
 <div>
-    Enter hostname where Redis is running
+    Enter hostname where Redis is running.
 </div>

--- a/plugin/src/main/resources/io/jenkins/plugins/redis/RedisFingerprintStorage/help-port.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/redis/RedisFingerprintStorage/help-port.html
@@ -1,0 +1,27 @@
+<!--
+The MIT License
+
+Copyright (c) 2020, Jenkins project contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<div>
+    Specify the port on which Redis instance is running.
+</div>

--- a/plugin/src/main/resources/io/jenkins/plugins/redis/RedisFingerprintStorage/help-socketTimeout.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/redis/RedisFingerprintStorage/help-socketTimeout.html
@@ -1,0 +1,27 @@
+<!--
+The MIT License
+
+Copyright (c) 2020, Jenkins project contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<div>
+    Set the socket timeout duration in milliseconds.
+</div>

--- a/plugin/src/main/resources/io/jenkins/plugins/redis/RedisFingerprintStorage/help-ssl.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/redis/RedisFingerprintStorage/help-ssl.html
@@ -1,0 +1,27 @@
+<!--
+The MIT License
+
+Copyright (c) 2020, Jenkins project contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<div>
+    Check if SSL is enabled.
+</div>

--- a/plugin/src/main/resources/io/jenkins/plugins/redis/RedisFingerprintStorage/help-ssl.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/redis/RedisFingerprintStorage/help-ssl.html
@@ -23,5 +23,5 @@ THE SOFTWARE.
 -->
 
 <div>
-    Check if SSL is enabled.
+    Select if SSL is enabled.
 </div>


### PR DESCRIPTION
Introduces help pages that show when the adjacent `?` is clicked.
<img width="1071" alt="Screen Shot 2020-08-09 at 7 12 01 PM" src="https://user-images.githubusercontent.com/27735438/89733613-3b0d2480-da74-11ea-8f84-5af25c8227d4.png">
